### PR TITLE
[INTERIM - DO NOT MERGE] Template the default UX and add display modes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,8 @@ fallback_version = "0.0.0"
 where = ["src"]
 
 [tool.setuptools.package-data]
-"gamatrix.templates" = ["*.jinja"]
-"gamatrix.static" = ["*.png", "*.jpg", "*.css", "*.js"]
+"gamatrix.templates" = ["*.jinja", "**/*.jinja"]
+"gamatrix.static" = ["*.png", "*.jpg", "*.css", "*.js", "**/*.css"]
 "gamatrix.static.profile_img" = ["*.png", "*.jpg"]
 
 [tool.mypy]

--- a/src/gamatrix/auth/routes.py
+++ b/src/gamatrix/auth/routes.py
@@ -12,7 +12,7 @@ from gamatrix.auth.service import COOKIE_NAME
 from gamatrix.config import get_settings
 from gamatrix.constants import API_TOKEN_NAME_MAX_LENGTH
 from gamatrix.storage.dynamo import Repository
-from gamatrix.templating import templates
+from gamatrix.templating import authenticated_template, templates
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 
@@ -98,7 +98,7 @@ def passkey_management(
     user: dict = Depends(current_user),
     repo: Repository = Depends(get_repo),
 ):
-    return templates.TemplateResponse(
+    return authenticated_template(
         request,
         "passkeys.html.jinja",
         {"user": user, "passkeys": _passkey_credentials(user, repo)},
@@ -111,10 +111,10 @@ def list_passkeys(
     user: dict = Depends(current_user),
     repo: Repository = Depends(get_repo),
 ):
-    return templates.TemplateResponse(
+    return authenticated_template(
         request,
         "passkeys_list.html.jinja",
-        {"passkeys": _passkey_credentials(user, repo)},
+        {"user": user, "passkeys": _passkey_credentials(user, repo)},
     )
 
 

--- a/src/gamatrix/games/preferences.py
+++ b/src/gamatrix/games/preferences.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+DISPLAY_MODES = ("light", "dark", "high-contrast", "color-blind")
+
 DEFAULT_PREFERENCES: dict[str, Any] = {
     "include_single_player": False,
     "installed_only": False,
@@ -12,6 +14,8 @@ DEFAULT_PREFERENCES: dict[str, Any] = {
     "selected_users": "all",
     "exclusive": False,
     "show_keys": False,
+    # None means follow the browser's light/dark preference.
+    "display_mode": None,
 }
 
 
@@ -20,4 +24,6 @@ def merge_preferences(stored: dict | None) -> dict:
     merged = dict(DEFAULT_PREFERENCES)
     if stored:
         merged.update({k: v for k, v in stored.items() if k in DEFAULT_PREFERENCES})
+    if merged["display_mode"] not in DISPLAY_MODES:
+        merged["display_mode"] = None
     return merged

--- a/src/gamatrix/games/routes.py
+++ b/src/gamatrix/games/routes.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, Request
-from fastapi.responses import HTMLResponse
 from fastapi.responses import JSONResponse
+from fastapi.responses import HTMLResponse
 
 from gamatrix.auth.dependencies import (
     current_user,
@@ -24,7 +24,7 @@ from gamatrix.games.web import WebCompareOptions
 from gamatrix.jobs import create_enrichment_job, is_job_stale
 from gamatrix.storage.dynamo import Repository
 from gamatrix.storage.queue import get_queue
-from gamatrix.templating import templates
+from gamatrix.templating import authenticated_template
 
 router = APIRouter(tags=["games"])
 
@@ -60,7 +60,7 @@ def games_page(
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
     result = service.compare(repo, opts.to_query())
     caption = web.build_caption(users, opts, result)
-    return templates.TemplateResponse(
+    return authenticated_template(
         request,
         "games.html.jinja",
         {
@@ -87,10 +87,11 @@ def games_table(
     opts = _parse_options(request, user, repo)
     result = service.compare(repo, opts.to_query())
     caption = web.build_caption(users, opts, result)
-    return templates.TemplateResponse(
+    return authenticated_template(
         request,
         "games_table.html.jinja",
         {
+            "user": user,
             "users": users,
             "games": web.present_games(result, opts),
             "caption": caption,
@@ -126,10 +127,10 @@ def job_status(
         or job.get("status") in (JOB_COMPLETED, JOB_FAILED)
         or is_job_stale(job)
     )
-    return templates.TemplateResponse(
+    return authenticated_template(
         request,
         "job_status.html.jinja",
-        {"job": job, "job_id": job_id, "done": done},
+        {"user": user, "job": job, "job_id": job_id, "done": done},
     )
 
 
@@ -151,10 +152,11 @@ def refresh_missing(
         repo.put_game({**game, "enrichment_status": ENRICHMENT_PENDING})
     release_keys = [g["release_key"] for g in missing]
     job_id = create_enrichment_job(repo, get_queue(), release_keys)
-    return templates.TemplateResponse(
+    return authenticated_template(
         request,
         "job_status.html.jinja",
         {
+            "user": admin,
             "job": repo.get_job(job_id) if job_id else None,
             "job_id": job_id,
             "done": job_id is None,
@@ -176,10 +178,11 @@ def refresh_all(
         if game:
             repo.put_game({**game, "enrichment_status": ENRICHMENT_PENDING})
     job_id = create_enrichment_job(repo, get_queue(), release_keys)
-    return templates.TemplateResponse(
+    return authenticated_template(
         request,
         "job_status.html.jinja",
         {
+            "user": admin,
             "job": repo.get_job(job_id) if job_id else None,
             "job_id": job_id,
             "done": job_id is None,

--- a/src/gamatrix/preferences.py
+++ b/src/gamatrix/preferences.py
@@ -9,11 +9,11 @@ from fastapi.responses import HTMLResponse, JSONResponse, Response
 
 from gamatrix.auth.dependencies import current_user, current_user_api, get_repo
 from gamatrix.constants import DISPLAY_NAME_MAX_LENGTH, PROFILE_PIC_MAX_UPLOAD_SIZE
-from gamatrix.games.preferences import merge_preferences
+from gamatrix.games.preferences import DISPLAY_MODES, merge_preferences
 from gamatrix.helpers import pic_url
 from gamatrix.images import process_profile_pic
 from gamatrix.storage.dynamo import Repository
-from gamatrix.templating import templates
+from gamatrix.templating import authenticated_template
 
 router = APIRouter(tags=["preferences"])
 
@@ -41,7 +41,7 @@ def preferences_form(
     repo: Repository = Depends(get_repo),
 ):
     users = {str(u["user_id"]): u for u in repo.scan_users() if u.get("user_id")}
-    return templates.TemplateResponse(
+    return authenticated_template(
         request,
         "preferences.html.jinja",
         {
@@ -68,6 +68,14 @@ async def save_preferences(
         return source.get(name) in ("true", "on", "1")
 
     selected = form.getlist("user") or qp.getlist("user")
+    current = merge_preferences(user.get("preferences", {}))
+    requested_mode = form.get("display_mode")
+    if requested_mode == "system":
+        display_mode = None
+    elif requested_mode in DISPLAY_MODES:
+        display_mode = requested_mode
+    else:
+        display_mode = current["display_mode"]
     prefs = {
         "include_single_player": flag("single_player"),
         "installed_only": flag("installed_only"),
@@ -76,6 +84,7 @@ async def save_preferences(
         "exclude_platforms": form.getlist("exclude") or qp.getlist("exclude"),
         "default_view": form.get("view", qp.get("view", "list")),
         "selected_users": selected if selected else "all",
+        "display_mode": display_mode,
     }
     repo.update_user(user["email"], {"preferences": prefs})
     return Response(status_code=204)

--- a/src/gamatrix/static/templates/default/style.css
+++ b/src/gamatrix/static/templates/default/style.css
@@ -1,0 +1,195 @@
+/* gamatrix v2 — dark theme carried over from v1 */
+:root {
+  --bg: rgb(50, 50, 50);
+  --fg: lightgray;
+  --accent: rgb(124, 207, 228);
+  --row-a: rgb(180, 227, 239);
+  --row-b: rgb(201, 235, 243);
+  --row-text: #102027;
+  --owned: rgb(182, 215, 168);
+  --unowned: rgb(234, 153, 153);
+}
+
+/* The default UX intentionally renders every mode exactly like the original. */
+:root,
+body[data-mode="light"],
+body[data-mode="dark"],
+body[data-mode="high-contrast"],
+body[data-mode="color-blind"] {
+  --bg: rgb(50, 50, 50);
+  --fg: lightgray;
+  --accent: rgb(124, 207, 228);
+  --row-a: rgb(180, 227, 239);
+  --row-b: rgb(201, 235, 243);
+  --row-text: #102027;
+  --owned: rgb(182, 215, 168);
+  --unowned: rgb(234, 153, 153);
+}
+
+body {
+  background-color: var(--bg);
+  color: var(--fg);
+  font-family: sans-serif;
+  margin: 0;
+  padding: 1rem 1.5rem;
+}
+
+a { color: var(--accent); }
+a:visited { color: lightseagreen; }
+
+h1, h2 { font-weight: 600; }
+
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid #666;
+  padding-bottom: 0.5rem;
+  margin-bottom: 1rem;
+}
+.topbar .right { display: flex; gap: 1rem; align-items: center; }
+
+/* Filter bar */
+.filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem 1.5rem;
+  align-items: flex-start;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid #555;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin-bottom: 1rem;
+}
+.filters fieldset { border: none; margin: 0; padding: 0; }
+.filters legend { font-weight: 600; margin-bottom: 0.25rem; }
+.filters label { display: inline-flex; align-items: center; gap: 4px; }
+.filter-group { display: flex; flex-direction: column; gap: 2px; }
+.platform-grid { display: grid; grid-template-columns: repeat(2, auto); gap: 2px 12px; }
+
+button, .btn {
+  background: var(--accent);
+  color: var(--row-text);
+  border: none;
+  border-radius: 4px;
+  padding: 6px 12px;
+  font-size: 0.95rem;
+  cursor: pointer;
+}
+button:hover, .btn:hover { filter: brightness(1.1); }
+button.secondary { background: #777; color: white; }
+
+/* Results table */
+table.results {
+  /* Firefox can't position:sticky a cell inside a border-collapse:collapse
+     table (bugzilla 1488080), so use separate borders and rebuild the 1px grid
+     from one-sided cell borders. The header below then keeps its own borders
+     when pinned, which collapse would have dropped. */
+  border-collapse: separate;
+  border-spacing: 0;
+  width: 100%;
+  border-left: 1px solid black;
+}
+table.results th, table.results td {
+  border-right: 1px solid black;
+  border-bottom: 1px solid black;
+  padding: 4px 8px;
+  color: var(--row-text);
+}
+table.results caption { color: var(--fg); text-align: left; margin-bottom: 0.5rem; }
+table.results thead th {
+  background-color: var(--accent);
+  cursor: pointer;
+  user-select: none;
+  border-top: 1px solid black;
+  /* Keep the heading row visible while scrolling the results. The page itself
+     scrolls (the topbar isn't fixed), so stick to the viewport top. */
+  position: sticky;
+  top: 0;
+  /* Paint above the colored owned/unowned cells that scroll underneath. */
+  z-index: 2;
+}
+table.results thead th:hover { filter: brightness(1.05); }
+table.results tbody tr:nth-child(odd) { background-color: var(--row-a); }
+table.results tbody tr:nth-child(even) { background-color: var(--row-b); }
+table.results tr.subthreshold td { color: grey; }
+/* Grid view: per-user ownership cells (green = owned, red = not owned), v1 scheme. */
+table.results td.owned { background-color: var(--owned); }
+table.results td.unowned { background-color: var(--unowned); }
+.platform-icons { float: right; white-space: nowrap; }
+.platform-icons img { vertical-align: middle; }
+.sort-arrow { font-size: 0.8em; }
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+/* Job progress */
+.job-progress {
+  background: rgba(124, 207, 228, 0.15);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 1rem;
+}
+.bar { background: #333; border-radius: 4px; height: 10px; overflow: hidden; }
+.bar > span { display: block; height: 100%; background: var(--accent); }
+
+/* Auth forms */
+.card {
+  max-width: 360px;
+  margin: 3rem auto;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid #555;
+  border-radius: 8px;
+  padding: 1.5rem;
+}
+.card h2 { margin-top: 0; }
+.card input[type=email], .card input[type=password], .card input[type=text] {
+  width: 100%;
+  padding: 8px;
+  margin: 6px 0 12px;
+  box-sizing: border-box;
+  border-radius: 4px;
+  border: 1px solid #888;
+}
+.card.wide { max-width: 720px; margin: 1rem auto; }
+.separator { color: #aaa; text-align: center; }
+.passkey-list, .token-list { list-style: none; padding: 0; }
+.passkey-list li, .token-list li {
+  display: flex; gap: 1rem; align-items: center; margin: 0.75rem 0;
+}
+.passkey-list li .muted, .token-list li .muted { flex: 1; }
+.token-box {
+  white-space: pre-wrap;
+  word-break: break-all;
+  background: #1b1b1b;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 0.75rem;
+  font-family: monospace;
+  font-size: 0.85rem;
+}
+.help-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1rem;
+  height: 1rem;
+  border: 1px solid #888;
+  border-radius: 50%;
+  color: #bbb;
+  cursor: help;
+  font-size: 0.75rem;
+  line-height: 1;
+}
+.help-icon:focus { outline: 1px solid var(--accent); outline-offset: 2px; }
+.error { color: #ff8a80; }
+.muted { color: #aaa; font-size: 0.9rem; }

--- a/src/gamatrix/templates/default/base.html.jinja
+++ b/src/gamatrix/templates/default/base.html.jinja
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% block title %}gamatrix{% endblock %}</title>
+    {# Version query busts the browser cache on each deploy so CSS changes
+       (e.g. the sticky results header) aren't masked by a stale stylesheet. #}
+    <link rel="stylesheet" href="/static/templates/default/style.css?v={{ version }}">
+    <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+</head>
+<body{% if display_mode %} data-mode="{{ display_mode }}"{% endif %}>
+{% block body %}{% endblock %}
+<footer class="muted" style="margin-top:2rem;">gamatrix v{{ version }}</footer>
+</body>
+</html>

--- a/src/gamatrix/templates/default/games.html.jinja
+++ b/src/gamatrix/templates/default/games.html.jinja
@@ -1,0 +1,98 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>gamatrix</h2>
+    <div class="right">
+        <span class="muted">{{ user.email }}</span>
+        <a href="/upload">Upload DB</a>
+        <a href="/preferences">Preferences</a>
+        <form method="post" action="/auth/logout" style="display:inline;">
+            <button class="secondary" type="submit">Sign out</button>
+        </form>
+    </div>
+</div>
+
+<form id="filters"
+      hx-get="/games/table"
+      hx-target="#games-container"
+      hx-trigger="change"
+      hx-include="#filters"
+      class="filters">
+
+    {# Marks requests as coming from the filter form so the server treats an
+       unchecked checkbox as "off" rather than falling back to a saved pref. #}
+    <input type="hidden" name="filters_active" value="1">
+
+    <fieldset class="filter-group">
+        <legend>Users</legend>
+        {% for uid, u in users.items() %}
+        <label title="DB updated: {{ u.get('db_updated_at', 'never') }}">
+            <input type="checkbox" name="user" value="{{ uid }}"
+                   {% if uid in opts.selected_user_ids %}checked{% endif %}>
+            {% set pu = pic_url(u) %}
+            {% if pu %}<img src="{{ pu }}" width="18" height="18">{% endif %}
+            {{ u.username }}
+        </label>
+        {% endfor %}
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>View</legend>
+        <label><input type="radio" name="view" value="list"
+            {% if not is_grid %}checked{% endif %}> Game list</label>
+        <label><input type="radio" name="view" value="grid"
+            {% if is_grid %}checked{% endif %}> Game grid</label>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Options</legend>
+        <label><input type="checkbox" name="single_player" value="true"
+            {% if opts.include_single_player %}checked{% endif %}> Include single-player</label>
+        <label><input type="checkbox" name="installed_only" value="true"
+            {% if opts.installed_only %}checked{% endif %}> Installed only</label>
+        <label><input type="checkbox" name="exclusive" value="true"
+            {% if opts.exclusive %}checked{% endif %}> Exclusively owned</label>
+        <label><input type="checkbox" name="randomize" value="true"
+            {% if opts.randomize %}checked{% endif %}> Pick a random game</label>
+        <label><input type="checkbox" name="show_keys" value="true"
+            {% if opts.show_keys %}checked{% endif %}> Show product keys</label>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Exclude platforms</legend>
+        <div class="platform-grid">
+            {% for p in platforms %}
+            <label><input type="checkbox" name="exclude" value="{{ p }}"
+                {% if p in opts.exclude_platforms %}checked{% endif %}>
+                <img src="/static/{{ p }}.png" width="18" height="18"> {{ p|capitalize }}</label>
+            {% endfor %}
+        </div>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>&nbsp;</legend>
+        <button type="button"
+                hx-post="/preferences"
+                hx-include="#filters"
+                hx-swap="none">Save as defaults</button>
+        {% if user.is_admin %}
+        <button type="button" class="secondary"
+                hx-post="/games/refresh-igdb"
+                hx-target="#job-status">Refresh missing IGDB</button>
+        <button type="button" class="secondary"
+                hx-post="/games/refresh-igdb-all"
+                hx-target="#job-status"
+                hx-confirm="Re-fetch IGDB data for ALL games?">Refresh all IGDB</button>
+        {% endif %}
+    </fieldset>
+</form>
+
+<div id="job-status">
+    {% if job_id %}{% include "job_status.html.jinja" %}{% endif %}
+</div>
+
+<div id="games-container">
+    {% include "games_table.html.jinja" %}
+</div>
+{% endblock %}

--- a/src/gamatrix/templates/default/games_table.html.jinja
+++ b/src/gamatrix/templates/default/games_table.html.jinja
@@ -1,0 +1,95 @@
+{# Renders the results table. Swapped in by HTMX on filter/sort changes. #}
+{% macro sort_header(label, col) %}
+    {% set next_dir = 'desc' if (opts.sort == col and opts.direction == 'asc') else 'asc' %}
+    <th hx-get="/games/table?sort={{ col }}&dir={{ next_dir }}"
+        hx-include="#filters"
+        hx-target="#games-container">
+        {{ label }}
+        {% if opts.sort == col %}
+        <span class="sort-arrow">{{ '▲' if opts.direction == 'asc' else '▼' }}</span>
+        {% endif %}
+    </th>
+{% endmacro %}
+
+{% set selected = opts.selected_user_ids %}
+<table class="results">
+    <caption>{{ caption }}</caption>
+    <thead>
+        <tr>
+            {{ sort_header('Title', 'title') }}
+            {% if is_grid %}
+                {% for uid in selected %}
+                {% if uid in users %}
+                <th title="{{ users[uid].username }}">
+                    {% set pu = pic_url(users[uid]) %}
+                    {% if pu %}
+                    <img src="{{ pu }}" width="20" height="20">
+                    {% else %}{{ users[uid].username }}{% endif %}
+                </th>
+                {% endif %}
+                {% endfor %}
+            {% endif %}
+            {{ sort_header('Players', 'players') }}
+            {{ sort_header('Rating', 'rating') }}
+            {% if not is_grid %}
+                {{ sort_header('Installed', 'installed') }}
+            {% endif %}
+            <th>Comment</th>
+            {% if opts.show_keys %}<th>Release Key</th>{% endif %}
+        </tr>
+    </thead>
+    <tbody>
+    {% for game in games %}
+        {% set mp = game.max_players|default(0)|int %}
+        <tr class="{{ 'subthreshold' if (mp > 0 and mp < selected|length) else '' }}">
+            <td>
+                {% if game.url %}<a href="{{ game.url }}">{{ game.title }}</a>
+                {% else %}{{ game.title }}{% endif %}
+                <span class="platform-icons">
+                    {% for p in game.platforms %}
+                    {% if p in platforms %}
+                    <img src="/static/{{ p }}.png" width="20" height="20" title="{{ p }}">
+                    {% else %}
+                    <img src="/static/profile_img/question_block.jpg" width="20" height="20" title="{{ p }}">
+                    {% endif %}
+                    {% endfor %}
+                </span>
+            </td>
+            {% if is_grid %}
+                {% for uid in selected %}
+                {% if uid in users %}
+                <td class="{{ 'owned' if uid in game.owners else 'unowned' }}" style="text-align:center;">
+                    <span class="visually-hidden">{{ 'Owned' if uid in game.owners else 'Not owned' }}</span>
+                    {% if uid in game.installed %}
+                        {% set pu = pic_url(users[uid]) %}
+                        {% if pu %}
+                        <img src="{{ pu }}" width="18" height="18" title="installed">
+                        {% else %}✓{% endif %}
+                    {% endif %}
+                </td>
+                {% endif %}
+                {% endfor %}
+            {% endif %}
+            <td>{% if mp > 0 %}{{ mp }}{% endif %}</td>
+            <td>{% if game.rating %}{{ game.rating }}{% endif %}</td>
+            {% if not is_grid %}
+            <td style="text-align:center;">
+                {% if selected|length == game.installed|length and game.installed %}
+                    <b>✓</b>
+                {% else %}
+                    {% for uid in game.installed if uid in users %}
+                    {% set pu = pic_url(users[uid]) %}
+                    {% if pu %}
+                    <img src="{{ pu }}" width="18" height="18" title="{{ users[uid].username }}">
+                    {% else %}{{ users[uid].username }}{% endif %}
+                    {% endfor %}
+                {% endif %}
+            </td>
+            {% endif %}
+            <td>{{ game.comment }}</td>
+            {% if opts.show_keys %}<td>{{ game.release_key }}</td>{% endif %}
+        </tr>
+    {% endfor %}
+    </tbody>
+</table>
+{% if not games %}<p class="muted">No games match the current filters.</p>{% endif %}

--- a/src/gamatrix/templates/default/job_status.html.jinja
+++ b/src/gamatrix/templates/default/job_status.html.jinja
@@ -1,0 +1,23 @@
+{# Enrichment progress. Polls itself every 3s; when done, reloads the table. #}
+{% if done %}
+    {# Job finished: pull in fresh data, then this element clears itself out. #}
+    <div hx-get="/games/table"
+         hx-include="#filters"
+         hx-target="#games-container"
+         hx-trigger="load"
+         hx-swap="innerHTML">
+    </div>
+{% else %}
+    {% set total = job.total|default(1) %}
+    {# Clamp: progress should never exceed total, but guard the display in case
+       a job's count was inflated by a retry before it settled (see #131). #}
+    {% set done_count = [job.completed_count|default(0), total]|min %}
+    {% set pct = (done_count * 100 // total) if total else 0 %}
+    <div class="job-progress"
+         hx-get="/api/jobs/{{ job_id }}"
+         hx-trigger="every 3s"
+         hx-swap="outerHTML">
+        Updating game data from IGDB… {{ done_count }} / {{ total }}
+        <div class="bar"><span style="width: {{ pct }}%;"></span></div>
+    </div>
+{% endif %}

--- a/src/gamatrix/templates/default/passkeys.html.jinja
+++ b/src/gamatrix/templates/default/passkeys.html.jinja
@@ -1,0 +1,50 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — passkeys{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>Passkeys</h2>
+    <div class="right"><a href="/preferences">Back to preferences</a></div>
+</div>
+
+<div class="card wide">
+    <h3>Add a passkey</h3>
+    <p class="muted">Passkeys can use this device, a synced provider, a phone, or a compatible security key.</p>
+    <form id="passkey-register">
+        <label for="friendly_name">Passkey name</label>
+        <input type="text" id="friendly_name" name="friendly_name" maxlength="100"
+               value="Gamatrix passkey for {{ user.username }}" required>
+        <label for="current_password">Current password
+            <span class="help-icon" title="Required to verify your identity before adding a passkey"
+                  aria-label="Required to verify your identity before adding a passkey" tabindex="0">?</span>
+        </label>
+        <input type="password" id="current_password" name="password" required autocomplete="current-password">
+        <button type="submit">Add passkey</button>
+    </form>
+    <p id="passkey-waiting" class="muted" hidden>Waiting for passkey creation to complete...</p>
+    <p id="passkey-error" class="error" hidden></p>
+</div>
+
+<div class="card wide">
+    <h3>Registered passkeys</h3>
+    {% if passkeys %}
+    <ul class="passkey-list">
+        {% for passkey in passkeys %}
+        <li>
+            <strong>{{ passkey.friendly_name }}</strong>
+            <span class="muted">
+                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
+                {% if passkey.backed_up %}, backed up{% endif %}
+                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
+            </span>
+            <button type="button" class="secondary delete-passkey"
+                    data-credential-id="{{ passkey.credential_id }}">Delete</button>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="muted">No passkeys registered.</p>
+    {% endif %}
+</div>
+<script src="/static/passkeys.js"></script>
+<script>window.gamatrixPasskeys.enableManagement();</script>
+{% endblock %}

--- a/src/gamatrix/templates/default/passkeys_list.html.jinja
+++ b/src/gamatrix/templates/default/passkeys_list.html.jinja
@@ -1,0 +1,28 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — passkeys{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>Passkeys</h2>
+    <div class="right"><a href="/preferences">Back to preferences</a></div>
+</div>
+
+<div class="card wide">
+    <h3>Registered passkeys</h3>
+    {% if passkeys %}
+    <ul class="passkey-list">
+        {% for passkey in passkeys %}
+        <li>
+            <strong>{{ passkey.friendly_name }}</strong>
+            <span class="muted">
+                {% if passkey.backup_eligible %}sync-capable{% else %}device-bound{% endif %}
+                {% if passkey.backed_up %}, backed up{% endif %}
+                {% if passkey.created_at %} - added {{ passkey.created_at[:10] }}{% endif %}
+            </span>
+        </li>
+        {% endfor %}
+    </ul>
+    {% else %}
+    <p class="muted">No passkeys registered.</p>
+    {% endif %}
+</div>
+{% endblock %}

--- a/src/gamatrix/templates/default/preferences.html.jinja
+++ b/src/gamatrix/templates/default/preferences.html.jinja
@@ -1,0 +1,159 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — preferences{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>Preferences</h2>
+    <div class="right"><a href="/games">Back to games</a></div>
+</div>
+
+<form id="profile" method="post" action="/profile" class="filters"
+      hx-post="/profile" hx-swap="none"
+      hx-on::after-request="if(event.detail.successful){this.querySelector('.saved').style.display='inline';this.querySelector('.error').style.display='none'}else{const e=this.querySelector('.error');e.textContent=JSON.parse(event.detail.xhr.responseText).error;e.style.display='inline';this.querySelector('.saved').style.display='none'}">
+    <fieldset class="filter-group">
+        <legend>Display name</legend>
+        <label>
+            <input type="text" name="username" value="{{ user.username }}"
+                   maxlength="32" required>
+        </label>
+        <button type="submit">Save name</button>
+        <span class="saved muted" style="display:none;">Saved ✓</span>
+        <span class="error" style="display:none;color:#c00;"></span>
+    </fieldset>
+</form>
+
+<div id="profilepic" class="filters">
+    <fieldset class="filter-group">
+        <legend>Profile picture</legend>
+        {% set pu = pic_url(user) %}
+        <img class="pic-preview" width="48" height="48"
+             src="{{ pu or '/static/profile_img/question_block.jpg' }}">
+        <input type="file" id="pic-file" accept="image/*">
+        <button type="button" onclick="uploadProfilePic()">Upload</button>
+        <span class="saved muted" style="display:none;">Saved ✓</span>
+        <span class="error" style="display:none;color:#c00;"></span>
+    </fieldset>
+</div>
+<script>
+// Send the file as the raw request body so the server can size-cap it as it
+// streams, rather than receiving a fully-buffered multipart upload.
+async function uploadProfilePic() {
+    const box = document.getElementById('profilepic');
+    const saved = box.querySelector('.saved');
+    const error = box.querySelector('.error');
+    const file = document.getElementById('pic-file').files[0];
+    if (!file) { return; }
+    saved.style.display = 'none';
+    error.style.display = 'none';
+    let data = {};
+    try {
+        const resp = await fetch('/profile/pic', {
+            method: 'POST',
+            headers: {'Content-Type': file.type || 'application/octet-stream'},
+            body: file,
+        });
+        data = await resp.json().catch(() => ({}));
+        if (!resp.ok) { throw new Error(data.error || 'Upload failed.'); }
+    } catch (e) {
+        error.textContent = e.message || 'Upload failed.';
+        error.style.display = 'inline';
+        return;
+    }
+    if (data.pic_url) { box.querySelector('.pic-preview').src = data.pic_url; }
+    saved.style.display = 'inline';
+}
+
+function applyDisplayMode() {
+    const form = document.getElementById('filters');
+    const mode = form.querySelector('select[name="display_mode"]').value;
+    const saved = form.querySelector('.saved');
+    document.body.removeAttribute('data-mode');
+    if (mode !== 'system') {
+        document.body.dataset.mode = mode;
+    }
+    saved.textContent = 'Save preferences to keep change';
+    saved.style.display = 'inline';
+}
+</script>
+
+<div class="filters">
+    <fieldset class="filter-group">
+        <legend>Passkeys</legend>
+        <button type="button" onclick="window.location.href='/auth/passkeys'">Manage passkeys</button>
+        <span class="muted">Add, review, or remove passkeys for this account.</span>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>API tokens</legend>
+        <button type="button" onclick="window.location.href='/auth/tokens'">Manage API tokens</button>
+        <span class="muted">Create tokens for unattended, scheduled DB uploads.</span>
+    </fieldset>
+</div>
+
+<form id="filters" method="post" action="/preferences" class="filters"
+      hx-post="/preferences" hx-swap="none"
+      hx-on::after-request="const s=this.querySelector('.saved');s.textContent='Saved ✓';s.style.display='inline'">
+
+    <fieldset class="filter-group">
+        <legend>Display mode</legend>
+        <span class="muted">Your browser preference is used until you choose a mode.</span>
+        <label>
+            <select name="display_mode">
+                <option value="system"{% if prefs.display_mode is none %} selected{% endif %}>System Setting</option>
+                {% for mode in ['light', 'dark', 'high-contrast', 'color-blind'] %}
+                <option value="{{ mode }}"{% if prefs.display_mode == mode %} selected{% endif %}>
+                    {{ mode|replace('-', ' ')|title }}
+                </option>
+                {% endfor %}
+            </select>
+        </label>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Default users</legend>
+        {% for uid, u in users.items() %}
+        <label>
+            <input type="checkbox" name="user" value="{{ uid }}"
+                {% if prefs.selected_users == 'all' or uid in prefs.selected_users %}checked{% endif %}>
+            {{ u.username }}
+        </label>
+        {% endfor %}
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Default view</legend>
+        <label><input type="radio" name="view" value="list"
+            {% if prefs.default_view == 'list' %}checked{% endif %}> Game list</label>
+        <label><input type="radio" name="view" value="grid"
+            {% if prefs.default_view == 'grid' %}checked{% endif %}> Game grid</label>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Default options</legend>
+        <label><input type="checkbox" name="single_player" value="true"
+            {% if prefs.include_single_player %}checked{% endif %}> Include single-player</label>
+        <label><input type="checkbox" name="installed_only" value="true"
+            {% if prefs.installed_only %}checked{% endif %}> Installed only</label>
+        <label><input type="checkbox" name="exclusive" value="true"
+            {% if prefs.exclusive %}checked{% endif %}> Exclusively owned</label>
+        <label><input type="checkbox" name="show_keys" value="true"
+            {% if prefs.show_keys %}checked{% endif %}> Show product keys</label>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>Exclude platforms</legend>
+        <div class="platform-grid">
+            {% for p in platforms %}
+            <label><input type="checkbox" name="exclude" value="{{ p }}"
+                {% if p in prefs.exclude_platforms %}checked{% endif %}> {{ p|capitalize }}</label>
+            {% endfor %}
+        </div>
+    </fieldset>
+
+    <fieldset class="filter-group">
+        <legend>&nbsp;</legend>
+        <button type="button" onclick="applyDisplayMode()">Apply</button>
+        <button type="submit">Save preferences</button>
+        <span class="saved muted" style="display:none;">Saved ✓</span>
+    </fieldset>
+</form>
+{% endblock %}

--- a/src/gamatrix/templates/default/upload.html.jinja
+++ b/src/gamatrix/templates/default/upload.html.jinja
@@ -1,0 +1,43 @@
+{% extends "base.html.jinja" %}
+{% block title %}gamatrix — upload DB{% endblock %}
+{% block body %}
+<div class="topbar">
+    <h2>Upload your GOG Galaxy database</h2>
+    <div class="right"><a href="/games">Back to games</a></div>
+</div>
+
+<div class="card" style="max-width:540px; margin:1rem 0;">
+    <p>Your GOG Galaxy DB is usually at:</p>
+    <p><code>C:\ProgramData\GOG.com\Galaxy\storage\galaxy-2.0.db</code></p>
+    <input type="file" id="dbfile" accept=".db">
+    <button id="uploadBtn" type="button">Upload</button>
+    <p id="status" class="muted"></p>
+    <p class="muted">Want this to happen automatically on a schedule?
+    Set up <a href="/auth/tokens">an API token for unattended uploads</a>.</p>
+</div>
+
+<script>
+const statusEl = document.getElementById('status');
+
+document.getElementById('uploadBtn').addEventListener('click', async () => {
+    const file = document.getElementById('dbfile').files[0];
+    if (!file) { statusEl.textContent = 'Choose a file first.'; return; }
+
+    statusEl.textContent = 'Requesting upload URL…';
+    const presign = await fetch('/upload/presign').then(r => r.json());
+
+    const form = new FormData();
+    for (const [k, v] of Object.entries(presign.fields)) form.append(k, v);
+    form.append('file', file);
+
+    statusEl.textContent = 'Uploading…';
+    const put = await fetch(presign.url, { method: 'POST', body: form });
+    if (!put.ok) { statusEl.textContent = 'Upload failed.'; return; }
+
+    statusEl.textContent = 'Processing database…';
+    const done = await fetch('/upload/complete', { method: 'POST' }).then(r => r.json());
+    statusEl.textContent = 'Done! Your library has been updated. Redirecting…';
+    setTimeout(() => window.location = '/games', 1500);
+});
+</script>
+{% endblock %}

--- a/src/gamatrix/templating.py
+++ b/src/gamatrix/templating.py
@@ -1,18 +1,63 @@
-"""Shared Jinja2 template environment for the web routes."""
+"""Stable public and default authenticated Jinja environments."""
 
 from __future__ import annotations
 
 from pathlib import Path
 
 from fastapi.templating import Jinja2Templates
+from starlette.background import BackgroundTask
+from starlette.responses import HTMLResponse
 
 from gamatrix import __version__
 from gamatrix.constants import PLATFORMS
+from gamatrix.games.preferences import merge_preferences
 from gamatrix.helpers import pic_url
 
 TEMPLATES_DIR = Path(__file__).parent / "templates"
-
+AUTHENTICATED_TEMPLATE_NAMES = (
+    "base.html.jinja",
+    "games.html.jinja",
+    "games_table.html.jinja",
+    "job_status.html.jinja",
+    "passkeys.html.jinja",
+    "passkeys_list.html.jinja",
+    "preferences.html.jinja",
+    "upload.html.jinja",
+)
 templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
-templates.env.globals["version"] = __version__
-templates.env.globals["platforms"] = list(PLATFORMS)
-templates.env.globals["pic_url"] = pic_url
+
+
+def _configure(environment: Jinja2Templates) -> Jinja2Templates:
+    environment.env.globals["version"] = __version__
+    environment.env.globals["platforms"] = list(PLATFORMS)
+    environment.env.globals["pic_url"] = pic_url
+    return environment
+
+
+_configure(templates)
+authenticated_templates = _configure(
+    Jinja2Templates(directory=str(TEMPLATES_DIR / "default"))
+)
+
+
+def authenticated_template(
+    request,
+    name: str,
+    context: dict,
+    status_code: int = 200,
+    headers: dict[str, str] | None = None,
+    media_type: str | None = None,
+    background: BackgroundTask | None = None,
+) -> HTMLResponse:
+    """Render an authenticated page or fragment with the account's saved mode."""
+    user = context.get("user") or {}
+    mode = merge_preferences(user.get("preferences", {})).get("display_mode")
+    return authenticated_templates.TemplateResponse(
+        request,
+        name,
+        {**context, "display_mode": mode},
+        status_code=status_code,
+        headers=headers,
+        media_type=media_type,
+        background=background,
+    )

--- a/src/gamatrix/upload.py
+++ b/src/gamatrix/upload.py
@@ -25,7 +25,7 @@ from gamatrix.gogdb.ingest import ingest_db_file
 from gamatrix.storage.dynamo import Repository
 from gamatrix.storage.queue import get_queue
 from gamatrix.storage.s3 import get_s3
-from gamatrix.templating import templates
+from gamatrix.templating import authenticated_template
 
 log = logging.getLogger(__name__)
 
@@ -38,7 +38,7 @@ def _upload_key(user: dict) -> str:
 
 @router.get("/upload", response_class=HTMLResponse)
 def upload_page(request: Request, user: dict = Depends(current_user)):
-    return templates.TemplateResponse(request, "upload.html.jinja", {"user": user})
+    return authenticated_template(request, "upload.html.jinja", {"user": user})
 
 
 @router.get("/upload/presign")

--- a/tests/test_preferences.py
+++ b/tests/test_preferences.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import pytest
+from fastapi.testclient import TestClient
 
 from gamatrix import preferences
+from gamatrix.app import app
+from gamatrix.auth.dependencies import current_user, current_user_api, get_repo
 from gamatrix.constants import DISPLAY_NAME_MAX_LENGTH
+from gamatrix.games.preferences import merge_preferences
 from gamatrix.helpers import pic_url
 
 
@@ -51,3 +55,95 @@ def test_pic_url_falls_back_to_static_seeded_pic():
 
 def test_pic_url_none_when_no_pic():
     assert pic_url({"user_id": "7"}) is None
+
+
+def test_invalid_stored_display_mode_falls_back_to_system_preference():
+    assert merge_preferences({"display_mode": "<script>"})["display_mode"] is None
+
+
+def test_save_preferences_persists_mode(repo):
+    user = {
+        "email": "user@x.com",
+        "username": "User",
+        "user_id": "1",
+        "preferences": {"display_mode": None},
+    }
+    repo.put_user(user)
+    app.dependency_overrides[get_repo] = lambda: repo
+    app.dependency_overrides[current_user_api] = lambda: user
+    try:
+        response = TestClient(app).post(
+            "/preferences",
+            data={"display_mode": "high-contrast", "user": "1"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 204
+    assert repo.get_user("user@x.com")["preferences"]["display_mode"] == "high-contrast"
+
+
+def test_save_preferences_persists_system_mode_as_none(repo):
+    user = {
+        "email": "user@x.com",
+        "username": "User",
+        "user_id": "1",
+        "preferences": {"display_mode": "dark"},
+    }
+    repo.put_user(user)
+    app.dependency_overrides[get_repo] = lambda: repo
+    app.dependency_overrides[current_user_api] = lambda: user
+    try:
+        response = TestClient(app).post(
+            "/preferences",
+            data={"display_mode": "system", "user": "1"},
+        )
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 204
+    assert repo.get_user("user@x.com")["preferences"]["display_mode"] is None
+
+
+def test_filter_auto_save_preserves_display_mode(repo):
+    user = {
+        "email": "user@x.com",
+        "username": "User",
+        "user_id": "1",
+        "preferences": {"display_mode": "color-blind"},
+    }
+    repo.put_user(user)
+    app.dependency_overrides[get_repo] = lambda: repo
+    app.dependency_overrides[current_user_api] = lambda: user
+    try:
+        response = TestClient(app).post("/preferences?user=1&single_player=true")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 204
+    stored = repo.get_user("user@x.com")["preferences"]
+    assert stored["display_mode"] == "color-blind"
+
+
+def test_preferences_form_selects_system_setting_for_none(repo):
+    user = {
+        "email": "user@x.com",
+        "username": "User",
+        "user_id": "1",
+        "preferences": {"display_mode": None},
+    }
+    repo.put_user(user)
+    app.dependency_overrides[get_repo] = lambda: repo
+    app.dependency_overrides[current_user] = lambda: user
+    try:
+        response = TestClient(app).get("/preferences")
+    finally:
+        app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    assert '<select name="display_mode">' in response.text
+    assert '<option value="system" selected>System Setting</option>' in response.text
+    assert '<button type="button" onclick="applyDisplayMode()">Apply</button>' in response.text
+    assert "function applyDisplayMode()" in response.text
+    assert "Save preferences to keep change" in response.text
+    assert "s.textContent='Saved ✓'" in response.text

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 import re
+from pathlib import Path
 
-from gamatrix.templating import templates
+from gamatrix.games.preferences import DISPLAY_MODES, merge_preferences
+from gamatrix.templating import (
+    AUTHENTICATED_TEMPLATE_NAMES,
+    TEMPLATES_DIR,
+    authenticated_templates,
+    templates,
+)
 
 
 def test_stylesheet_link_is_cache_busted():
@@ -12,3 +19,39 @@ def test_stylesheet_link_is_cache_busted():
     aren't masked by a browser serving a stale /static/style.css."""
     html = templates.env.get_template("base.html.jinja").render()
     assert re.search(r'href="/static/style\.css\?v=[^"]+"', html)
+
+
+def test_default_authenticated_ux_has_the_complete_template_contract():
+    for name in AUTHENTICATED_TEMPLATE_NAMES:
+        authenticated_templates.env.get_template(name)
+
+
+def test_default_authenticated_base_uses_cache_busted_stylesheet():
+    html = authenticated_templates.env.get_template("base.html.jinja").render()
+    assert '/static/templates/default/style.css?v=' in html
+
+
+def test_authenticated_templates_apply_only_valid_explicit_modes():
+    template = authenticated_templates.env.get_template("base.html.jinja")
+    assert 'data-mode="dark"' in template.render(display_mode="dark")
+    assert "data-mode" not in template.render(display_mode=None)
+
+
+def test_default_stylesheet_defines_every_required_mode_and_stays_small():
+    path = Path(TEMPLATES_DIR.parent / "static" / "templates" / "default" / "style.css")
+    css = path.read_text()
+    assert path.stat().st_size < 20_000
+    for mode in DISPLAY_MODES:
+        assert f'data-mode="{mode}"' in css
+
+
+def test_default_preferences_template_includes_apply_preview_controls():
+    html = authenticated_templates.env.get_template("preferences.html.jinja").render(
+        user={"email": "user@x.com", "username": "User", "user_id": "1"},
+        users={"1": {"username": "User", "user_id": "1"}},
+        prefs=merge_preferences({"display_mode": None}),
+    )
+    assert '<button type="button" onclick="applyDisplayMode()">Apply</button>' in html
+    assert "function applyDisplayMode()" in html
+    assert "Save preferences to keep change" in html
+    assert "s.textContent='Saved ✓'" in html


### PR DESCRIPTION
!! # AFTER THE `ux-data-layer` PR gets in, we raise this PR from `ux-template-mode`.

_This PR on my personal repo will be used to ensure we keep track of upstream changes in the ux-data-layer branch as PR advice is resolved. We will rebase this branch and ensure everything continues to work here until that PR finally merges into `master` and we will then raise this PR._

## Details: Templatize the default (current) UX and add 'no-op' display modes.

### What

Moves the current authenticated UX into a `default` template set and adds per-user display mode preferences, while keeping the existing user-facing flow intact. This makes the authenticated UI themeable without yet introducing a second visual template.

### How

Added an authenticated template wrapper, nested `templates/default/` and matching static assets, plus preference persistence/validation for `display_mode`. The routes now render authenticated pages through that wrapper, so the next PR can add `modern` as a deployment-selected template instead of rewriting route behavior again.

--- 

## AFTER `ux-template-mode` lands

We will raise this last PR in this series from branch `ux-modern-template` which builds the final layer on top of the ux-data-layer + ux-template-mode to add this new 'modern' template and realizes our final state with a fully-templatized UX for Gamatrix.

### What

Adds a second authenticated template, `modern`, and makes the deployment choose between `default` and `modern`. This keeps the data and display-mode work from earlier PRs intact while introducing the new visual layer as an additive change.

### How

Added `templates/modern/` and its stylesheet, then generalized the authenticated templating setup to validate and load the configured UX template. Runtime and CDK config now pass `UX_TEMPLATE` through deployment, with tests covering template selection and config validation.

